### PR TITLE
Remove check for MediaWiki environment from setup file

### DIFF
--- a/Mermaid.php
+++ b/Mermaid.php
@@ -7,9 +7,6 @@ use Mermaid\HookRegistry;
  *
  * @defgroup mermaid Mermaid
  */
-if ( !defined( 'MEDIAWIKI' ) ) {
-	die( 'This file is part of the Mermaid extension, it is not a valid entry point.' );
-}
 
 /**
  * @codeCoverageIgnore


### PR DESCRIPTION
This PR addresses or contains:

Currently, Mermaid autoloads its setup file via Composer's autoloader and exits if it does not detect a MediaWiki environment. This prevents developers from executing tools also installed via composer such as the `phpunit` binary, or `phpcs`/`phpcbf`/`phan` etc., as Mermaid will immediately exit the process. As a fix, remove the environment check; this is also consistent with how Semantic MediaWiki itself behaves since https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/1732.

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed
